### PR TITLE
회원가입 / 회원탈퇴 기능 구현 / 로그인 기능은 주석처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+### .properties file ###
+application-db.properties

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
+
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
@@ -27,6 +28,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'at.favre.lib:bcrypt:0.10.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/sparta_3rd_newsfeed/Sparta3rdNewsfeedApplication.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/Sparta3rdNewsfeedApplication.java
@@ -2,7 +2,10 @@ package com.example.sparta_3rd_newsfeed;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+
+@EnableJpaAuditing
 @SpringBootApplication
 public class Sparta3rdNewsfeedApplication {
 

--- a/src/main/java/com/example/sparta_3rd_newsfeed/common/encoder/PasswordEncoder.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/common/encoder/PasswordEncoder.java
@@ -1,0 +1,19 @@
+package com.example.sparta_3rd_newsfeed.common.encoder;
+
+import at.favre.lib.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoder {
+
+    private static final int COST = 12;
+
+    public String encode(String password) {
+        return BCrypt.withDefaults().hashToString(COST, password.toCharArray());
+    }
+
+    public boolean matches(String rawPassword, String encodedPassword) {
+        BCrypt.Result result = BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword);
+        return result.verified;
+    }
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/common/entity/BaseEntity.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/common/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.sparta_3rd_newsfeed.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/common/exception/GlobalException.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/common/exception/GlobalException.java
@@ -1,0 +1,14 @@
+package com.example.sparta_3rd_newsfeed.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice
+public class GlobalException {
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<String> handleResponseStatusException(ResponseStatusException e) {
+        return new ResponseEntity<>(e.getReason(),e.getStatusCode());
+    }
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/common/filter/AuthFilter.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/common/filter/AuthFilter.java
@@ -1,0 +1,42 @@
+package com.example.sparta_3rd_newsfeed.common.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class AuthFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        // 회원가입 및 로그인 요청은 필터에서 제외
+        String requestURI = httpRequest.getRequestURI();
+
+        if (requestURI.startsWith("/members/signup") || requestURI.startsWith("/members/login")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+
+        // 세션에서 사용자 ID 가져오기
+        Object user = httpRequest.getSession().getAttribute("member");
+
+        if (user == null) {
+            log.warn("Unauthorized access attempt to {}", requestURI);
+            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그인이 필요합니다.");
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/controller/MemberController.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/controller/MemberController.java
@@ -1,0 +1,66 @@
+package com.example.sparta_3rd_newsfeed.member.controller;
+
+import com.example.sparta_3rd_newsfeed.member.dto.requestDto.DeleteMemberRequestDto;
+import com.example.sparta_3rd_newsfeed.member.dto.requestDto.LoginRequestDto;
+import com.example.sparta_3rd_newsfeed.member.dto.requestDto.SignUpRequestDto;
+import com.example.sparta_3rd_newsfeed.member.dto.responseDto.LoginResponseDto;
+import com.example.sparta_3rd_newsfeed.member.dto.responseDto.SignUpResponseDto;
+import com.example.sparta_3rd_newsfeed.member.entity.Member;
+import com.example.sparta_3rd_newsfeed.member.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(
+            @Valid @RequestBody SignUpRequestDto signUpRequestDto,
+            BindingResult bindingResult
+            ){
+
+        if(bindingResult.hasErrors()) {
+            List<String> errorMessages = bindingResult.getFieldErrors()
+                    .stream()
+                    .map(error -> error.getField() + " : " + error.getDefaultMessage()) // 필드명과 메시지 함께 반환
+                    .collect(Collectors.toList());
+            return ResponseEntity.badRequest().body(errorMessages);
+        }
+        SignUpResponseDto signUpResponseDto = memberService.signUp(signUpRequestDto);
+        return new ResponseEntity<>(signUpResponseDto, HttpStatus.CREATED);
+    }
+
+//    @PostMapping("/login")
+//    public ResponseEntity<LoginResponseDto> login(
+//            @RequestBody LoginRequestDto loginRequestDto,
+//            HttpServletRequest request) {
+//
+//        Member member = memberService.login(loginRequestDto);
+//
+//        HttpSession session = request.getSession();
+//        session.setAttribute("member", member);
+//        return new ResponseEntity<>(new LoginResponseDto("로그인 성공"), HttpStatus.OK);
+//    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteMember(
+            @RequestBody DeleteMemberRequestDto requestDto
+            ){
+
+        memberService.deleteMember(requestDto);
+        return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
+    }
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/requestDto/DeleteMemberRequestDto.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/requestDto/DeleteMemberRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.sparta_3rd_newsfeed.member.dto.requestDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeleteMemberRequestDto {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/requestDto/LoginRequestDto.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/requestDto/LoginRequestDto.java
@@ -1,0 +1,18 @@
+//package com.example.sparta_3rd_newsfeed.member.dto.requestDto;
+//
+//
+//import lombok.AllArgsConstructor;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//import lombok.RequiredArgsConstructor;
+//
+//@Getter
+//@AllArgsConstructor
+//@NoArgsConstructor
+//public class LoginRequestDto {
+//
+//    private String email;
+//    private String password;
+//    private String profileImg;
+//    private String profileBio;
+//}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/requestDto/SignUpRequestDto.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/requestDto/SignUpRequestDto.java
@@ -1,0 +1,31 @@
+package com.example.sparta_3rd_newsfeed.member.dto.requestDto;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignUpRequestDto {
+
+    @NotBlank(message ="사용자 이름은 필수 입력 항목입니다.")
+    private String username;
+
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "올바른 이메일 형식을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    private String password;
+
+    private String profileImg;
+
+    private String profileBio;
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/responseDto/LoginResponseDto.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/responseDto/LoginResponseDto.java
@@ -1,0 +1,14 @@
+/*
+package com.example.sparta_3rd_newsfeed.member.dto.responseDto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LoginResponseDto {
+
+    private final String message;
+
+}
+*/

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/responseDto/SignUpResponseDto.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/responseDto/SignUpResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.sparta_3rd_newsfeed.member.dto.responseDto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SignUpResponseDto {
+    private final String username;
+    private final String email;
+
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/entity/Member.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/entity/Member.java
@@ -1,0 +1,40 @@
+package com.example.sparta_3rd_newsfeed.member.entity;
+
+import com.example.sparta_3rd_newsfeed.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@AllArgsConstructor
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "profile_img_id")
+    private String profileImg;
+
+    @Column(nullable=false, name = "name")
+    private String username;
+
+    @Column(nullable = false,unique = true,name = "member_email")
+    private String email;
+
+    @Column(nullable =false, name = "member_password")
+    private String password;
+
+    @Column(columnDefinition = "TEXT", name = "profile_bio")
+    private String profileBio;
+
+    @Column(nullable = false,name = "is_delete")
+    private boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public Member() {}
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.example.sparta_3rd_newsfeed.member.repository;
+
+import com.example.sparta_3rd_newsfeed.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByEmailAndIsDeletedFalse(String email);
+}

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/service/MemberService.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/service/MemberService.java
@@ -1,0 +1,92 @@
+package com.example.sparta_3rd_newsfeed.member.service;
+
+import com.example.sparta_3rd_newsfeed.common.encoder.PasswordEncoder;
+import com.example.sparta_3rd_newsfeed.member.dto.requestDto.DeleteMemberRequestDto;
+import com.example.sparta_3rd_newsfeed.member.dto.requestDto.LoginRequestDto;
+import com.example.sparta_3rd_newsfeed.member.dto.requestDto.SignUpRequestDto;
+import com.example.sparta_3rd_newsfeed.member.dto.responseDto.SignUpResponseDto;
+import com.example.sparta_3rd_newsfeed.member.entity.Member;
+import com.example.sparta_3rd_newsfeed.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public SignUpResponseDto signUp(SignUpRequestDto signUpRequestDto) {
+        // 활성화된 계정이 있는지 확인
+        Optional<Member> existingMember = memberRepository.findByEmailAndIsDeletedFalse(signUpRequestDto.getEmail());
+
+        if (existingMember.isPresent()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일 입니다.");
+        }
+
+        // 비밀번호 유효성 검사
+        if (!signUpRequestDto.getPassword().matches("(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호는 8~16자 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.");
+        }
+
+        // 기존 탈퇴한 회원이 있는지 확인
+        Optional<Member> deletedMember = memberRepository.findByEmail(signUpRequestDto.getEmail());
+
+        if (deletedMember.isPresent()) {
+            // 기존 계정을 재활성화
+            Member member = deletedMember.get();
+            member.setDeleted(false); // 계정 활성화
+            member.setPassword(passwordEncoder.encode(signUpRequestDto.getPassword())); // 비밀번호 재설정
+            member.setUsername(signUpRequestDto.getUsername());
+            member.setProfileImg(signUpRequestDto.getProfileImg());
+            member.setProfileBio(signUpRequestDto.getProfileBio());
+            memberRepository.save(member);
+
+            return new SignUpResponseDto(member.getUsername(), member.getEmail());
+        }
+
+        // 신규 회원가입 처리
+        Member member = new Member();
+        member.setUsername(signUpRequestDto.getUsername());
+        member.setPassword(passwordEncoder.encode(signUpRequestDto.getPassword()));
+        member.setEmail(signUpRequestDto.getEmail());
+        member.setProfileImg(signUpRequestDto.getProfileImg());
+        member.setProfileBio(signUpRequestDto.getProfileBio());
+
+        memberRepository.save(member);
+
+        return new SignUpResponseDto(member.getUsername(), member.getEmail());
+    }
+
+
+//    public Member login(LoginRequestDto loginRequestDto) {
+//        Member member = memberRepository.findByEmail(loginRequestDto.getEmail())
+//                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "이메일이나 비밀번호가 일치하지 않습니다."));
+//
+//        if (!passwordEncoder.matches(loginRequestDto.getPassword(), member.getPassword())) {
+//            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "이메일이나 비밀번호가 일치하지 않습니다.");
+//        }
+//
+//        return member;
+//    }
+
+
+    public void deleteMember(DeleteMemberRequestDto requestDto) {
+        Member member = memberRepository.findByEmail(requestDto.getEmail())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"이메일이나 비밀번호가 일치하지 않습니다."));
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), member.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "이메일이나 비밀번호가 일치하지 않습니다.");
+        }
+
+        member.setDeleted(true);
+        memberRepository.save(member);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
 spring.application.name=Sparta_3rd_Newsfeed
+spring.datasource.url=jdbc:mysql://localhost:3306/newsfeed
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.profiles.include=db
+
+spring.jpa.hibernate.ddl-auto=update
+
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.use_sql_comments=true
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,37 @@
+-- 데이터베이스 생성
+USE newsfeed;
+
+-- 회원 테이블
+CREATE TABLE member (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        profile_img_id VARCHAR(255) NULL,
+                        name VARCHAR(100) NOT NULL,
+                        member_email VARCHAR(255) NOT NULL UNIQUE,
+                        member_password VARCHAR(255) NOT NULL,
+                        profile_bio TEXT NULL,
+                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        isDelete BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+-- 게시물 테이블
+CREATE TABLE feed (
+                      id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                      member_id BIGINT NOT NULL,
+                      title VARCHAR(255) NOT NULL,
+                      feed_content TEXT NOT NULL,
+                      created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                      updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                      FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE
+);
+
+-- 친구 관계 테이블
+CREATE TABLE friend (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        sender_id BIGINT NOT NULL,
+                        receiver_id BIGINT NOT NULL,
+                        status ENUM('PENDING', 'ACCEPTED', 'REJECTED') NOT NULL DEFAULT 'PENDING',
+                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        FOREIGN KEY (sender_id) REFERENCES member(id) ON DELETE CASCADE,
+                        FOREIGN KEY (receiver_id) REFERENCES member(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## 반영 브랜치
ex) OneTwo_login -> dev

## 연관 이슈
ex) #이슈번호, #이슈번호

## 작업 내용
회원가입 기능 / 회원탈퇴 기능을 구현했습니다.
예외처리 ) 
1. 중복 이메일로 회원가입 불가
2. 비밀번호 형식 지정(8~16자 사이,영문자,숫자,특수기호 포함)
3. 탈퇴한 계정으로 로그인 불가
4. 탈퇴한 계정으로 다시 회원가입시 계정 복구
