### PR TITLE
문제 해결

### DIFF
--- a/src/main/java/com/example/sparta_3rd_newsfeed/friend/entity/Friend.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/friend/entity/Friend.java
@@ -1,7 +1,7 @@
 package com.example.sparta_3rd_newsfeed.friend.entity;
 
-import com.example.sparta_3rd_newsfeed.Member;
 import com.example.sparta_3rd_newsfeed.common.entity.BaseEntity;
+import com.example.sparta_3rd_newsfeed.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +18,7 @@ public class Friend extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id", nullable = false)
-    private Member sender;
+    private com.example.sparta_3rd_newsfeed.member.entity.Member sender;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id", nullable = false)

--- a/src/main/java/com/example/sparta_3rd_newsfeed/friend/repository/FriendRepository.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/friend/repository/FriendRepository.java
@@ -1,7 +1,8 @@
 package com.example.sparta_3rd_newsfeed.friend.repository;
 
-import com.example.sparta_3rd_newsfeed.Member;
+
 import com.example.sparta_3rd_newsfeed.friend.entity.Friend;
+import com.example.sparta_3rd_newsfeed.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/sparta_3rd_newsfeed/friend/service/FriendService.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/friend/service/FriendService.java
@@ -1,13 +1,14 @@
 package com.example.sparta_3rd_newsfeed.friend.service;
 
-import com.example.sparta_3rd_newsfeed.Member;
-import com.example.sparta_3rd_newsfeed.MemberRepository;
+
 import com.example.sparta_3rd_newsfeed.friend.entity.FriendStatus;
 import com.example.sparta_3rd_newsfeed.friend.dto.request.StatusUpdateRequestDto;
 import com.example.sparta_3rd_newsfeed.friend.dto.response.FriendResponseDto;
 import com.example.sparta_3rd_newsfeed.friend.dto.response.PageResponseDto;
 import com.example.sparta_3rd_newsfeed.friend.entity.Friend;
 import com.example.sparta_3rd_newsfeed.friend.repository.FriendRepository;
+import com.example.sparta_3rd_newsfeed.member.entity.Member;
+import com.example.sparta_3rd_newsfeed.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/controller/MemberController.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.example.sparta_3rd_newsfeed.member.controller;
 
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.DeleteMemberRequestDto;
-import com.example.sparta_3rd_newsfeed.member.dto.MemberUpdateRequestDto;
+import com.example.sparta_3rd_newsfeed.member.dto.requestDto.MemberUpdateRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.LoginRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.SignUpRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.responseDto.LoginResponseDto;
@@ -10,8 +10,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import com.example.sparta_3rd_newsfeed.member.entity.Member;
 import com.example.sparta_3rd_newsfeed.member.service.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,11 +28,6 @@ public class MemberController {
     private final MemberService memberService;
 
 
-    @Autowired
-    public MemberController(MemberService memberService) {
-        this.memberService = memberService;
-    }
-
     // 내 정보 수정
     @PutMapping("/me")
     public ResponseEntity<Member> updateProfile(
@@ -49,7 +42,7 @@ public class MemberController {
         Member updatedMember = memberService.updateMember(loginUserId, updateRequestDto);
         return ResponseEntity.ok(updatedMember);
     }
-}
+
 
     @PostMapping("/signup")
     public ResponseEntity<?> signup(

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/requestDto/MemberUpdateRequestDto.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/requestDto/MemberUpdateRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.sparta_3rd_newsfeed.member.dto;
+package com.example.sparta_3rd_newsfeed.member.dto.requestDto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -19,7 +19,7 @@ public class MemberUpdateRequestDto {
     private String newPassword;  // 새 비밀번호
 
     @NotBlank(message = "새 비밀번호를 확인해주세요.")
-    private boolean passwordcheck;  // 새 비밀번호 확인
+    private String passwordcheck;  // 새 비밀번호 확인
 
     private String profileImg;  // 프로필 이미지 URL
     @Size(max = 30, message = "소개글은 30자 이내로 작성해주세요.")

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/entity/Member.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/entity/Member.java
@@ -21,17 +21,12 @@ import java.util.List;
 @Setter
 @Entity
 @AllArgsConstructor
-
-public class Member extends BaseEntity implements UserDetails {
+public class Member extends BaseEntity implements UserDetails{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-  
-    private String email;
-    private String password;
-    private String profileBio;
-    private String profileImgId;
+
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -85,4 +80,5 @@ public class Member extends BaseEntity implements UserDetails {
     private LocalDateTime deletedAt;
 
     public Member() {}
+
 }

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/repository/MemberRepository.java
@@ -1,8 +1,11 @@
 package com.example.sparta_3rd_newsfeed.member.repository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
 import com.example.sparta_3rd_newsfeed.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.server.ResponseStatusException;
+
 import java.util.Optional;
 
 
@@ -11,5 +14,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     
      Optional<Member> findByEmailAndIsDeletedFalse(String email);
+
+    // findByIdOrElseThrow 메서드 추가
+    default Member findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+    }
 }
 

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/service/MemberService.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/service/MemberService.java
@@ -2,7 +2,7 @@ package com.example.sparta_3rd_newsfeed.member.service;
 
 import com.example.sparta_3rd_newsfeed.common.encoder.PasswordEncoder;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.DeleteMemberRequestDto;
-import com.example.sparta_3rd_newsfeed.member.dto.MemberUpdateRequestDto;
+import com.example.sparta_3rd_newsfeed.member.dto.requestDto.MemberUpdateRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.LoginRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.SignUpRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.responseDto.SignUpResponseDto;
@@ -12,10 +12,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import java.util.Optional;
 
 import java.util.regex.Matcher;
@@ -30,13 +27,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    
-    @Autowired
-    public MemberService(MemberRepository memberRepository, BCryptPasswordEncoder passwordEncoder) {
-        this.memberRepository = memberRepository;
-        this.passwordEncoder = passwordEncoder;
-        
-    }
 
     @Transactional
     public Member updateMember(Long memberId, MemberUpdateRequestDto updateRequestDto) {
@@ -50,9 +40,8 @@ public class MemberService {
         }
 
         // 3. 새 비밀번호 형식 검증 및 변경
-        // 3. 새 비밀번호 형식 검증 및 변경
-        if (updateRequestDto.isPasswordcheck()) {  // passwordcheck가 true일 때 새 비밀번호 확인
-            if (!updateRequestDto.getNewPassword().equals(updateRequestDto.getNewPassword())) {
+        if ("true".equals(updateRequestDto.getPasswordcheck())) {  // 문자열로 체크
+            if (!updateRequestDto.getNewPassword().equals(updateRequestDto.getPasswordcheck())) {
                 throw new IllegalArgumentException("새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.");
             }
 
@@ -80,7 +69,7 @@ public class MemberService {
 
         // 5. 프로필 이미지 수정
         if (updateRequestDto.getProfileImg() != null) {
-            member.setProfileImgId(updateRequestDto.getProfileImg());
+            member.setProfileImg(updateRequestDto.getProfileImg());
         }
 
         // 6. 수정된 회원 저장


### PR DESCRIPTION
## 반영 브랜치
feat/profile-management -> dev

## 연관 이슈
ex) #이슈번호, #이슈번호

## 작업 내용
pull을 해서 오류나는부분 수정
풀을 하면서 팀원끼리 달랐던 파일위치 import 부분에 member 쪽 부분을 수정하였습니다.
boolean으로 체크하던 새로운 비밀번호확인 부분을 String 으로 변경하였습니다.
 Member 클래스에서 implements 부분을 제거하려했으나 그렇게되면 오버라이드 기능이 오류가 생성되어서
냅둿습니다
Member클래스에 중복 되어있는 필드들이 발견되어 제거 하였습니다.
MemberService클래스에서 @RequiredArgsConstructor 어노테이션을 사용함으로 인해 생성자가 불필요해져 삭제하였습니다.
boolean으로 체크하던 새로운 비밀번호확인 부분을 String 으로 변경함으로 인해 새로운 비밀번호가 맞는지 중복 체크하는 코드를 변경하였습니다.
pull 을 함에있어 ProfileImg의 이름이 서로달라 오류나던부분의 이름을 통일해줫습니다.
## 단독 테스트 결과

## 리뷰 요구사항(선택)
