### PR TITLE
내정보 수정의 예외처리 오류 해결/단건조회와 회원조회만들기

### DIFF
--- a/src/main/java/com/example/sparta_3rd_newsfeed/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/common/exception/GlobalExceptionHandler.java
@@ -2,15 +2,17 @@ package com.example.sparta_3rd_newsfeed.common.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@ControllerAdvice(annotations = RestController.class)
+@RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<Map<String, String>> handleResponseStatusException(ResponseStatusException ex) {
@@ -34,6 +36,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException ex) {
         Map<String, Object> response = new HashMap<>();
         response.put("message", ex.getMessage());
+        response.put("status", 400); // 400 Bad Request
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException e) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
         response.put("status", 400); // 400 Bad Request
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/controller/MemberController.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.example.sparta_3rd_newsfeed.member.controller;
 
+import com.example.sparta_3rd_newsfeed.feed.entity.Like;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.DeleteMemberRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.LoginRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.MemberUpdateRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.SignUpRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.responseDto.LoginResponseDto;
+import com.example.sparta_3rd_newsfeed.member.dto.responseDto.MemberResponseDto;
 import com.example.sparta_3rd_newsfeed.member.dto.responseDto.SignUpResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -26,18 +28,56 @@ import java.util.stream.Collectors;
 public class MemberController {
 
     private final MemberService memberService;
+    // 단건 조회 - id 기준
+    @GetMapping("/{id}")
+    public ResponseEntity<MemberResponseDto> getMemberById(@PathVariable Long id) {
+        Member member = memberService.getMemberById(id); // id로 멤버 조회
+
+        if (member == null) {
+            return ResponseEntity.notFound().build(); // 멤버가 없으면 404 반환
+        }
+
+        MemberResponseDto responseDto = new MemberResponseDto(
+                member.getId(),
+                member.getUsername(),
+                member.getEmail(),
+                member.getProfileImg(),
+                member.getProfileBio(),
+                member.getCreatedAt(),
+                member.getUpdatedAt()
+        );
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    //멤버 다건조회
+    @GetMapping
+    public ResponseEntity<List<MemberResponseDto>> getMembersByUsername(@RequestParam String username) {
+        List<Member> members = memberService.getMembersByUsername(username); // 다건 조회
+
+        // List<Member>에서 List<MemberResponseDto>로 변환
+        List<MemberResponseDto> responseDtos = members.stream()
+                .map(member -> new MemberResponseDto(
+                        member.getId(),
+                        member.getUsername(),
+                        member.getEmail(),
+                        member.getProfileImg(),
+                        member.getProfileBio(),
+                        member.getCreatedAt(), // LocalDateTime 전달
+                        member.getUpdatedAt()  // LocalDateTime 전달
+                ))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responseDtos);
+    }
 
     // 내 정보 수정
     @PutMapping("/me")
     public ResponseEntity<Member> updateProfile(
             @SessionAttribute(name = "member") Member member,  // 로그인된 사용자
-            @RequestBody @Valid MemberUpdateRequestDto updateRequestDto,  // @Valid 추가
-            BindingResult bindingResult) {  // 유효성 검사 결과
+            @RequestBody @Valid MemberUpdateRequestDto updateRequestDto  // @Valid 추가
+            ) {
         //유효성 검사 오류 발생 확인
-        if (bindingResult.hasErrors()) {
-            return ResponseEntity.badRequest().body(null); //잘못된 요청시 400상태코드 반환
-        }
-
         Member updatedMember = memberService.updateMember(member.getId(), updateRequestDto);
         return ResponseEntity.ok(updatedMember);
     }
@@ -58,18 +98,6 @@ public class MemberController {
         SignUpResponseDto signUpResponseDto = memberService.signUp(signUpRequestDto);
         return new ResponseEntity<>(signUpResponseDto, HttpStatus.CREATED);
     }
-
-//    @PostMapping("/login")
-//    public ResponseEntity<LoginResponseDto> login(
-//            @RequestBody LoginRequestDto loginRequestDto,
-//            HttpServletRequest request) {
-//
-//        Member member = memberService.login(loginRequestDto);
-//
-//        HttpSession session = request.getSession();
-//        session.setAttribute("member", member);
-//        return new ResponseEntity<>(new LoginResponseDto("로그인 성공"), HttpStatus.OK);
-//    }
 
     @DeleteMapping("/delete")
     public ResponseEntity<String> deleteMember(

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/responseDto/MemberResponseDto.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/dto/responseDto/MemberResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.sparta_3rd_newsfeed.member.dto.responseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class MemberResponseDto {
+    private Long id;
+    private String username;
+    private String email;
+    private String profileImg;
+    private String profileBio;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}
+

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/entity/Member.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/entity/Member.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @Setter
 @Entity
 @AllArgsConstructor
-
+@NoArgsConstructor
 public class Member extends BaseEntity {
 
     @Id
@@ -43,7 +43,5 @@ public class Member extends BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
-
-    public Member() {}
 
 }

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/repository/MemberRepository.java
@@ -1,4 +1,6 @@
 package com.example.sparta_3rd_newsfeed.member.repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
@@ -6,6 +8,7 @@ import com.example.sparta_3rd_newsfeed.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -15,10 +18,19 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmailAndIsDeletedFalse(String email);
 
+    //특정 문자열을 포함하는 회원 조회
+    @Query("SELECT m FROM Member m WHERE m.username LIKE %:username%")
+    List<Member> findByUsernameLike(@Param("username") String username);
+
     // findByIdOrElseThrow 메서드 추가
     default Member findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
     }
+
+    List<Member> findByUsernameContaining(String username);
+
+    String username(String username);
 }
+
 

--- a/src/main/java/com/example/sparta_3rd_newsfeed/member/service/MemberService.java
+++ b/src/main/java/com/example/sparta_3rd_newsfeed/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.example.sparta_3rd_newsfeed.member.dto.requestDto.DeleteMemberRequest
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.LoginRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.MemberUpdateRequestDto;
 import com.example.sparta_3rd_newsfeed.member.dto.requestDto.SignUpRequestDto;
+import com.example.sparta_3rd_newsfeed.member.dto.responseDto.MemberResponseDto;
 import com.example.sparta_3rd_newsfeed.member.dto.responseDto.SignUpResponseDto;
 import com.example.sparta_3rd_newsfeed.member.entity.Member;
 import com.example.sparta_3rd_newsfeed.member.repository.MemberRepository;
@@ -16,7 +17,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -26,7 +29,23 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    //단건조회를 위한 메서드 추가
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."));
+    }
 
+    public List<Member> getMembersByUsername(String username) {
+        // username을 포함한 회원들을 조회
+        List<Member> members = memberRepository.findByUsernameContaining(username);
+
+        if (members.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다.");
+        }
+
+        return members;
+    }
+    //회원수정
     @Transactional
     public Member updateMember(Long memberId, MemberUpdateRequestDto updateRequestDto) {
         // 1. 회원 조회
@@ -49,9 +68,6 @@ public class MemberService {
 
         // 4. 소개글 수정
         if (updateRequestDto.getProfileBio() != null) {
-            if (updateRequestDto.getProfileBio().length() > 30) {
-                throw new IllegalArgumentException("소개글은 30자 이하로 작성해주세요.");
-            }
             member.setProfileBio(updateRequestDto.getProfileBio());
         }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.datasource.username=root
 spring.datasource.password=142mibn!@A
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
## 반영 브랜치
ex) feat/db -> dev

## 연관 이슈
ex) #이슈번호, #이슈번호

## 작업 내용
1.내정보 수정에 비밀번호가 문자와 특수문자 영어 하나씩 들어가야하는부분이 숫자만 나오면 response body 부분이 
예외처리를 나타내줘야 하지만 안나오는걸 해결
2.내정보수정에서 소개글 부분이 30자를넘어갈시  response body 부분이 예외처리를 나타내줘야하지만 안나오는걸 해결
3.프로필 단건조회를 만듬
4.다건 조회를만듬(이름을 입력시 그문자가 포함된사람 전부)
## 단독 테스트 결과
단독으로 테스트한결과 postman에선 예외처리와 성공된것들이 아주잘 표현이됨
{
  "oldPassword": "1234567@asd",
  "newPassword": "1234567777",
  "passwordcheck": "1234567777",
  "profileImg": "newImageUrl.jpg",
  "profileBio": "This is myaaaaaaaaaaaaaa  "
}
{
    "message": "새 비밀번호는 8~16자, 영문자, 숫자, 특수기호를 각각 하나 이상 포함해야 합니다.",
    "status": 400
}
이런식

## 리뷰 요구사항(선택)
-> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?